### PR TITLE
Add basic iOS React Native skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ Thumbs.db
 node_modules
 package-lock.json
 yarn.lock.secrets/
+
+# iOS project
+ios/node_modules

--- a/docs/ios-setup.md
+++ b/docs/ios-setup.md
@@ -1,0 +1,35 @@
+# iOS Setup
+
+This folder contains a lightweight React Native project used for testing RT25K bot functionality on iOS. The project lives in `ios/` at the repository root.
+
+## Prerequisites
+
+- Node.js 18+
+- Xcode with command line tools
+- `react-native` CLI (`npx react-native --version`)
+
+## Install Dependencies
+
+```bash
+cd ios
+npm install
+```
+
+## Running on Simulator
+
+```bash
+npm run ios
+```
+
+This will start the React Native packager and launch the iOS simulator.
+
+## Environment
+
+The UI expects a Discord bot token and optional API keys for Google Sheets and Challonge. Enter these on the login and configuration screens.
+
+## Building for Release
+
+1. Open `ios` in Xcode.
+2. Select your signing team and adjust bundle identifiers if needed.
+3. Build or archive the project via Xcode.
+

--- a/ios/App.js
+++ b/ios/App.js
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native';
+import LoginScreen from './src/screens/LoginScreen';
+import HomeScreen from './src/screens/HomeScreen';
+import ConfigScreen from './src/screens/ConfigScreen';
+
+export default function App() {
+  const [token, setToken] = useState(null);
+  const [config, setConfig] = useState(null);
+
+  if (!token) {
+    return <LoginScreen onLogin={setToken} />;
+  }
+
+  if (!config) {
+    return <ConfigScreen onSave={setConfig} />;
+  }
+
+  return (
+    <SafeAreaView style={{ flex: 1 }}>
+      <HomeScreen
+        token={token}
+        config={config}
+        onLogout={() => {
+          setConfig(null);
+          setToken(null);
+        }}
+      />
+    </SafeAreaView>
+  );
+}

--- a/ios/app.json
+++ b/ios/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "rt25kios",
+  "displayName": "RT25K iOS"
+}

--- a/ios/index.js
+++ b/ios/index.js
@@ -1,0 +1,5 @@
+import { AppRegistry } from 'react-native';
+import App from './App';
+import { name as appName } from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/ios/package.json
+++ b/ios/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "rt25k-ios",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "start": "react-native start",
+    "ios": "react-native run-ios"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.73.4",
+    "axios": "^1.9.0",
+    "discord-api-types": "^0.37.40"
+  }
+}

--- a/ios/src/api/challonge.js
+++ b/ios/src/api/challonge.js
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+export async function getTournament(tournamentId = 'final_drive', apiKey) {
+  const url = `https://api.challonge.com/v1/tournaments/${tournamentId}.json?api_key=${apiKey}&include_matches=1&include_participants=1`;
+  const res = await axios.get(url);
+  return res.data;
+}

--- a/ios/src/api/discord.js
+++ b/ios/src/api/discord.js
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+export async function sendMessage(token, channelId, content) {
+  const url = `https://discord.com/api/v10/channels/${channelId}/messages`;
+  const headers = {
+    Authorization: `Bot ${token}`,
+    'Content-Type': 'application/json'
+  };
+  await axios.post(url, { content }, { headers });
+}

--- a/ios/src/api/googleSheets.js
+++ b/ios/src/api/googleSheets.js
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+// Fetch standings from Google Sheets
+export async function getStandings(spreadsheetId, sheetName = 's4-standings', apiKey) {
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/${sheetName}?key=${apiKey}`;
+  const res = await axios.get(url);
+  return res.data.values;
+}

--- a/ios/src/screens/ConfigScreen.js
+++ b/ios/src/screens/ConfigScreen.js
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button } from 'react-native';
+
+export default function ConfigScreen({ onSave, initial }) {
+  const [spreadsheetId, setSpreadsheetId] = useState(initial?.spreadsheetId || '');
+  const [challongeKey, setChallongeKey] = useState(initial?.challongeKey || '');
+  const [googleApiKey, setGoogleApiKey] = useState(initial?.googleApiKey || '');
+
+  return (
+    <View style={{ padding: 20 }}>
+      <Text style={{ fontSize: 20, marginBottom: 10 }}>Configuration</Text>
+      <TextInput
+        placeholder="Google Spreadsheet ID"
+        value={spreadsheetId}
+        onChangeText={setSpreadsheetId}
+        style={{ borderWidth: 1, padding: 8, marginBottom: 10 }}
+      />
+      <TextInput
+        placeholder="Google API Key"
+        value={googleApiKey}
+        onChangeText={setGoogleApiKey}
+        style={{ borderWidth: 1, padding: 8, marginBottom: 10 }}
+      />
+      <TextInput
+        placeholder="Challonge API Key"
+        value={challongeKey}
+        onChangeText={setChallongeKey}
+        style={{ borderWidth: 1, padding: 8, marginBottom: 10 }}
+      />
+      <Button title="Save" onPress={() => onSave({ spreadsheetId, challongeKey, googleApiKey })} />
+    </View>
+  );
+}

--- a/ios/src/screens/HomeScreen.js
+++ b/ios/src/screens/HomeScreen.js
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { View, Text, Button, ScrollView } from 'react-native';
+import { getStandings } from '../api/googleSheets';
+import { getTournament } from '../api/challonge';
+import ConfigScreen from './ConfigScreen';
+
+export default function HomeScreen({ token, config, onLogout }) {
+  const [output, setOutput] = useState('');
+  const [showConfig, setShowConfig] = useState(false);
+
+  async function handleStandings() {
+    try {
+      const data = await getStandings(config.spreadsheetId, 's4-standings', config.googleApiKey);
+      setOutput(JSON.stringify(data, null, 2));
+    } catch (err) {
+      setOutput(err.message);
+    }
+  }
+
+  async function handleTournament() {
+    try {
+      const data = await getTournament('final_drive', config.challongeKey);
+      setOutput(JSON.stringify(data, null, 2));
+    } catch (err) {
+      setOutput(err.message);
+    }
+  }
+
+  if (showConfig) {
+    return (
+      <ConfigScreen
+        onSave={(cfg) => {
+          setShowConfig(false);
+          Object.assign(config, cfg);
+        }}
+        initial={config}
+      />
+    );
+  }
+
+  return (
+    <ScrollView contentInsetAdjustmentBehavior="automatic" style={{ padding: 20 }}>
+      <Text style={{ fontSize: 18, marginBottom: 10 }}>Logged in</Text>
+      <Button title="Fetch Standings" onPress={handleStandings} />
+      <Button title="Fetch Tournament" onPress={handleTournament} />
+      <Button title="Configure" onPress={() => setShowConfig(true)} />
+      <Button title="Logout" onPress={onLogout} />
+      {output ? <Text style={{ marginTop: 20 }}>{output}</Text> : null}
+    </ScrollView>
+  );
+}

--- a/ios/src/screens/LoginScreen.js
+++ b/ios/src/screens/LoginScreen.js
@@ -1,0 +1,20 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button } from 'react-native';
+
+export default function LoginScreen({ onLogin }) {
+  const [token, setToken] = useState('');
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 20 }}>
+      <Text style={{ fontSize: 24, marginBottom: 20 }}>Discord Bot Token</Text>
+      <TextInput
+        value={token}
+        onChangeText={setToken}
+        placeholder="Bot Token"
+        autoCapitalize="none"
+        style={{ borderWidth: 1, padding: 8, marginBottom: 20 }}
+      />
+      <Button title="Login" onPress={() => onLogin(token)} />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- add an `ios/` React Native skeleton with login and configuration screens
- add simple API helpers for Discord, Google Sheets and Challonge
- document build/run steps for the iOS project
- ignore `ios/node_modules`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683e12822f0c83288f9e0df60584d746