### PR TITLE
Add setConfig callback to HomeScreen

### DIFF
--- a/ios/App.js
+++ b/ios/App.js
@@ -21,6 +21,7 @@ export default function App() {
       <HomeScreen
         token={token}
         config={config}
+        setConfig={setConfig}
         onLogout={() => {
           setConfig(null);
           setToken(null);

--- a/ios/src/screens/HomeScreen.js
+++ b/ios/src/screens/HomeScreen.js
@@ -4,7 +4,7 @@ import { getStandings } from '../api/googleSheets';
 import { getTournament } from '../api/challonge';
 import ConfigScreen from './ConfigScreen';
 
-export default function HomeScreen({ token, config, onLogout }) {
+export default function HomeScreen({ token, config, setConfig, onLogout }) {
   const [output, setOutput] = useState('');
   const [showConfig, setShowConfig] = useState(false);
 
@@ -31,7 +31,7 @@ export default function HomeScreen({ token, config, onLogout }) {
       <ConfigScreen
         onSave={(cfg) => {
           setShowConfig(false);
-          Object.assign(config, cfg);
+          setConfig({ ...config, ...cfg });
         }}
         initial={config}
       />


### PR DESCRIPTION
## Summary
- pass `setConfig` from `App` into `HomeScreen`
- update config via `setConfig` when saving from `ConfigScreen`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683e1d253e208328b37d4ef9aae63d49