### PR TITLE
Add iOS test script

### DIFF
--- a/docs/ios-setup.md
+++ b/docs/ios-setup.md
@@ -23,6 +23,16 @@ npm run ios
 
 This will start the React Native packager and launch the iOS simulator.
 
+## Running Tests
+
+Run unit tests using React Native's built-in test runner:
+
+```bash
+npm test
+```
+
+This executes Jest tests defined in the `ios` project.
+
 ## Environment
 
 The UI expects a Discord bot token and optional API keys for Google Sheets and Challonge. Enter these on the login and configuration screens.

--- a/ios/package.json
+++ b/ios/package.json
@@ -4,7 +4,8 @@
   "version": "0.1.0",
   "scripts": {
     "start": "react-native start",
-    "ios": "react-native run-ios"
+    "ios": "react-native run-ios",
+    "test": "react-native test"
   },
   "dependencies": {
     "react": "18.2.0",


### PR DESCRIPTION
## Summary
- add `npm test` script to `ios/package.json`
- document how to run iOS tests

## Testing
- `npm test` *(fails: react-native not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e1d2796fc832894dd07e40c9eb349