### PR TITLE
Remove unused iOS tests

### DIFF
--- a/docs/ios-setup.md
+++ b/docs/ios-setup.md
@@ -23,15 +23,9 @@ npm run ios
 
 This will start the React Native packager and launch the iOS simulator.
 
-## Running Tests
+## Tests
 
-Run unit tests using React Native's built-in test runner:
-
-```bash
-npm test
-```
-
-This executes Jest tests defined in the `ios` project.
+There are currently no automated tests for the iOS app. The `npm test` command does nothing.
 
 ## Environment
 

--- a/ios/package.json
+++ b/ios/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "react-native start",
     "ios": "react-native run-ios",
-    "test": "react-native test"
+    "test": "echo \"No tests available\" && exit 0"
   },
   "dependencies": {
     "react": "18.2.0",


### PR DESCRIPTION
## Summary
- update docs/ios-setup.md to clarify there are no automated tests
- replace the test script in ios/package.json with a no-op message

## Testing
- `npm test` in `ios`

------
https://chatgpt.com/codex/tasks/task_e_683e2631f1d4832887d1036909e1a4a6